### PR TITLE
Restoring submission form automation

### DIFF
--- a/form.yml.erb
+++ b/form.yml.erb
@@ -30,9 +30,9 @@ attributes:
           data-hide-hgpus: true,
         ]
       - [ 'ckpt-g2', 'ckpt-g2',
-          data-set-hgputype: 'none',
+          data-set-hgputype: 'l40s',
+          data-hide-hgputype: 'true',
           data-set-hgpus: 0,
-          data-hide-hgpus: true,
         ]
       - [ 'ckpt-all', 'ckpt-all',
           data-set-hgputype: 'none',

--- a/form.yml.erb
+++ b/form.yml.erb
@@ -116,10 +116,8 @@ attributes:
   extra_jupyter_args: ""
 
 form:
-#  - haccount
-#  - hqueue
-  - auto_accounts
-  - auto_queues
+  - haccount
+  - hqueue
   - sif
   - custom_sif
   - jupyter_ui

--- a/form.yml.erb
+++ b/form.yml.erb
@@ -73,7 +73,11 @@ attributes:
       - [ "None", "none", data-set-hgpus: 0, data-hide-hgpus: true ]
       - [ "Any", "", data-set-hgpus: 0 ]
       <%- ckptgpus.each do |k, v| -%>
-      - [ "<%= v %>", "<%= k %>" ]
+      - [ "<%= v %>", "<%= k %>",
+        <%- if k == "l40s" -%>
+        data-option-for-hqueue-ckpt: "false",
+        <%- end -%>
+        ]
       <%- end -%>
   hgpus:
     label: GPUs

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -3,8 +3,8 @@ batch_connect:
   template: "basic"
 
 script:
-  queue_name: "<%= auto_queues %>"
-  accounting_id: "<%= auto_accounts %>"
+  queue_name: "<%= hqueue %>"
+  accounting_id: "<%= haccount %>"
   native:
     - "--ntasks"
     - "<%= htasks.blank? ? 1 : htasks.to_i %>"

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -19,4 +19,4 @@ nvflag="--nv"
 
 # Launch the Jupyter Notebook Server
 set -x
-apptainer exec ${nvflag} ${sif} jupyter ${ui} --config="${CONFIG_FILE}" ${extra_args}
+apptainer exec ${nvflag} ${sif} jupyter ${ui} --config="${CONFIG_FILE}" ${extra_args} --NotebookApp.root_dir=$HOME

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -19,4 +19,4 @@ nvflag="--nv"
 
 # Launch the Jupyter Notebook Server
 set -x
-apptainer exec ${nvflag} ${sif} jupyter ${ui} --config="${CONFIG_FILE}" ${extra_args} --NotebookApp.root_dir=$HOME
+apptainer exec ${nvflag} ${sif} jupyter ${ui} --config="${CONFIG_FILE}" ${extra_args}


### PR DESCRIPTION
To restore form automation:

Changes to form.yml.erb:

1. Set GPU type to L40S when a user selects the 'ckpt-g2' partition & hide GPU type drop down.
2. Hide the L40S option from the GPU type drop down when a user selects 'ckpt' rather than 'ckpt-all'.
3. Revert the change to OOD-provided accounts/queues.

Changes to submit.yml:

1. Revert the change to OOD-provided accounts/queues.