### PR TITLE
Feature/jupyter sans container

### DIFF
--- a/form.yml.erb
+++ b/form.yml.erb
@@ -89,7 +89,7 @@ attributes:
     min: 0
     max: 8
     value: 0
-  sif:
+  env:
     label: Server Environment
     widget: select
     help: Select 'Custom Container' if you have created your own Jupyter-Apptainer image.
@@ -97,24 +97,32 @@ attributes:
     - [
         "Container: minimal-notebook",
         "/mmfs1/sw/ondemand/containers/jupyter/minimal-notebook",
-        data-hide-custom-sif: true
+        data-hide-custom-sif: true,
+        data-set-module: false
       ]
     - [
         "Container: scipy-notebook",
         "/mmfs1/sw/ondemand/containers/jupyter/scipy-notebook",
-        data-hide-custom-sif: true
+        data-hide-custom-sif: true,
+        data-set-module: false
       ]
     - [
         "Container: datascience-notebook",
         "/mmfs1/sw/ondemand/containers/jupyter/datascience-notebook",
-        data-hide-custom-sif: true
+        data-hide-custom-sif: true,
+        data-set-module: false
         ]
     - [
-        "Module: minimal",
-        "module",
-        data-hide-custom-sif: true
+        "Custom Container",
+        "",
+        data-set-module: false
         ]
-    - [ "Custom Container", "" ]
+    - [
+        "Module: jupyter/minimal",
+        "jupyter/minimal",
+        data-hide-custom-sif: true,
+        data-set-module: true
+        ]
     value: "Default"
   custom_sif:
     label: Full path to your customized Jupyter-Apptainer container.
@@ -127,11 +135,14 @@ attributes:
     - ["Jupyter Lab", "lab" ]
     - ["Jupyter Notebook", "notebook" ]
   extra_jupyter_args: ""
+  module:
+    widget: "hidden_field"
+    value: false
 
 form:
   - haccount
   - hqueue
-  - sif
+  - env
   - custom_sif
   - jupyter_ui
   - extra_jupyter_args
@@ -141,4 +152,5 @@ form:
   - hgputype
   - hgpus
   - bc_num_hours
+  - module
 

--- a/form.yml.erb
+++ b/form.yml.erb
@@ -90,31 +90,31 @@ attributes:
     max: 8
     value: 0
   sif:
-    label: Jupyter Container
+    label: Server Environment
     widget: select
-    help: Select 'Custom' if you have created your own Jupyter-Apptainer image.
+    help: Select 'Custom Container' if you have created your own Jupyter-Apptainer image.
     options:
     - [
-        "jupyter/minimal-notebook",
+        "Container: minimal-notebook",
         "/mmfs1/sw/ondemand/containers/jupyter/minimal-notebook",
         data-hide-custom-sif: true
       ]
     - [
-        "jupyter/scipy-notebook",
+        "Container: scipy-notebook",
         "/mmfs1/sw/ondemand/containers/jupyter/scipy-notebook",
         data-hide-custom-sif: true
       ]
     - [
-        "jupyter/datascience-notebook",
+        "Container: datascience-notebook",
         "/mmfs1/sw/ondemand/containers/jupyter/datascience-notebook",
         data-hide-custom-sif: true
         ]
     - [
-        "None",
-        "none",
+        "Module",
+        "module",
         data-hide-custom-sif: true
         ]
-    - [ "Custom", "" ]
+    - [ "Custom Container", "" ]
     value: "Default"
   custom_sif:
     label: Full path to your customized Jupyter-Apptainer container.

--- a/form.yml.erb
+++ b/form.yml.erb
@@ -110,7 +110,7 @@ attributes:
         data-hide-custom-sif: true
         ]
     - [
-        "Module",
+        "Module: minimal",
         "module",
         data-hide-custom-sif: true
         ]

--- a/form.yml.erb
+++ b/form.yml.erb
@@ -108,7 +108,12 @@ attributes:
         "jupyter/datascience-notebook",
         "/mmfs1/sw/ondemand/containers/jupyter/datascience-notebook",
         data-hide-custom-sif: true
-      ]
+        ]
+    - [
+        "None",
+        "none",
+        data-hide-custom-sif: true
+        ]
     - [ "Custom", "" ]
     value: "Default"
   custom_sif:

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -20,10 +20,8 @@ nvflag="--nv"
 # Launch the Jupyter Notebook Server
 set -x
 
-if [[ $sif == "none" ]]; then
-	__conda_setup="$('/mmfs1/sw/ondemand/miniconda3/bin/conda' 'shell.bash' 'hook' 2> /dev/null)"
-        eval "$__conda_setup"
-        conda activate /mmfs1/sw/ondemand/condaenv
+if [[ $sif == "module" ]]; then
+	module --ignore_cache load "jupyter"
 	jupyter ${ui} --config="${CONFIG_FILE}" ${extra_args}
 else
 	apptainer exec ${nvflag} ${sif} jupyter ${ui} --config="${CONFIG_FILE}" ${extra_args}

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -19,4 +19,13 @@ nvflag="--nv"
 
 # Launch the Jupyter Notebook Server
 set -x
-apptainer exec ${nvflag} ${sif} jupyter ${ui} --config="${CONFIG_FILE}" ${extra_args}
+
+if [[ $sif == "none" ]]; then
+	__conda_setup="$('/mmfs1/sw/ondemand/miniconda3/bin/conda' 'shell.bash' 'hook' 2> /dev/null)"
+        eval "$__conda_setup"
+        conda activate /mmfs1/sw/ondemand/condaenv
+	jupyter ${ui} --config="${CONFIG_FILE}" ${extra_args}
+else
+	apptainer exec ${nvflag} ${sif} jupyter ${ui} --config="${CONFIG_FILE}" ${extra_args}
+fi
+

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -9,7 +9,7 @@ cd "${HOME}"
 # Benchmark info
 echo "TIMING - Starting jupyter at: $(date)"
 
-sif="<%= context.sif.blank? ? context.custom_sif : context.sif %>" #path to sif
+env="<%= context.env.blank? ? context.custom_sif : context.env %>"
 ui="<%= context.jupyter_ui %>" #lab or notebook
 extra_args="<%= context.extra_jupyter_args %>" #any extra args provided
 
@@ -19,11 +19,10 @@ nvflag="--nv"
 
 # Launch the Jupyter Notebook Server
 set -x
-
-if [[ $sif == "module" ]]; then
-	module --ignore_cache load "jupyter"
+<%- if context.module == true -%>
+	module --ignore_cache load $env
 	jupyter ${ui} --config="${CONFIG_FILE}" ${extra_args}
-else
-	apptainer exec ${nvflag} ${sif} jupyter ${ui} --config="${CONFIG_FILE}" ${extra_args}
-fi
+<%- else -%>
+	apptainer exec ${nvflag} ${env} jupyter ${ui} --config="${CONFIG_FILE}" ${extra_args}
+<%- end -%>
 


### PR DESCRIPTION
Added an element in the server environment selection drop down which allows users to choose either a container or a module for launching the jupyter server on Klone. Tested and confirmed as working via sandbox app by Kaichen and myself.